### PR TITLE
fix!: change the input files as direct argument

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,13 +10,12 @@ use clap::{Parser, ValueEnum};
     after_long_help = "Bugs can be reported on GitHub: https://github.com/azzamsa/gelatyx/issues"
 )]
 pub struct Opts {
-    /// Language used in code block
-    #[arg(value_enum)]
-    pub language: Language,
-
     /// File(s) to format
-    #[arg(short, long, num_args = 1..)]
     pub file: Vec<PathBuf>,
+
+    /// Language used in code block
+    #[arg(short, long, value_enum)]
+    pub language: Language,
 
     /// Specify an alternate configuration file
     #[arg(long)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,7 +19,7 @@ fn help() -> Result<(), Box<dyn Error>> {
 fn missing_lang() -> Result<(), Box<dyn Error>> {
     let mut cmd = Command::cargo_bin(crate_name!())?;
     let path = Path::new("tests").join("doesnt").join("exist");
-    cmd.arg("-f").arg(path);
+    cmd.arg(path);
     cmd.assert().failure().stderr(predicate::str::contains(
         "required arguments were not provided",
     ));
@@ -31,7 +31,7 @@ fn missing_lang() -> Result<(), Box<dyn Error>> {
 fn file_not_found() -> Result<(), Box<dyn Error>> {
     let mut cmd = Command::cargo_bin(crate_name!())?;
     let path = Path::new("tests").join("doesnt").join("exist");
-    cmd.arg("lua").arg("-f").arg(path);
+    cmd.arg(path).arg("--language").arg("lua");
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("File is not found"))
@@ -65,10 +65,10 @@ second line
 
     // Can't use glob here. It doesn't expand automatically
     // such in termninal invocation.
-    cmd.arg("lua")
-        .arg("-f")
-        .arg(md1.to_path_buf())
-        .arg(md2.to_path_buf());
+    cmd.arg(md1.to_path_buf())
+        .arg(md2.to_path_buf())
+        .arg("--language")
+        .arg("lua");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("2 files formatted"));
@@ -98,7 +98,7 @@ second line
     let input = temp_dir.child("nocode.md");
     input.write_str(content)?;
 
-    cmd.arg("lua").arg("-f").arg(input.to_path_buf());
+    cmd.arg(input.to_path_buf()).arg("--language").arg("lua");
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("1 file unchanged"));
@@ -128,9 +128,9 @@ second line
     let input = temp_dir.child("check.md");
     input.write_str(content)?;
 
-    cmd.arg("lua")
-        .arg("-f")
-        .arg(input.to_path_buf())
+    cmd.arg(input.to_path_buf())
+        .arg("--language")
+        .arg("lua")
         .arg("--check");
     cmd.assert()
         .success()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,7 +34,9 @@ fn file_not_found() -> Result<(), Box<dyn Error>> {
     cmd.arg("lua").arg("-f").arg(path);
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("File is not found"));
+        .stderr(predicate::str::contains("File is not found"))
+        .stderr(predicate::str::contains("1 file failed to format"));
+
     Ok(())
 }
 
@@ -47,7 +49,7 @@ first line
 
 ```lua
 local foo = require("bar")
-return { foo }
+return{foo}
 ```
 
 second line
@@ -67,7 +69,9 @@ second line
         .arg("-f")
         .arg(md1.to_path_buf())
         .arg(md2.to_path_buf());
-    cmd.assert().success();
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("2 files formatted"));
 
     let content1 = fs::read_to_string(md1)?;
     assert!(content1.contains(r#"return { foo }"#));
@@ -95,7 +99,9 @@ second line
     input.write_str(content)?;
 
     cmd.arg("lua").arg("-f").arg(input.to_path_buf());
-    cmd.assert().success();
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("1 file unchanged"));
 
     temp_dir.close()?;
     Ok(())
@@ -128,7 +134,8 @@ second line
         .arg("--check");
     cmd.assert()
         .success()
-        .stderr(predicate::str::contains("is unformatted"));
+        .stderr(predicate::str::contains("is unformatted"))
+        .stdout(predicate::str::contains("1 file would be formatted"));
 
     temp_dir.close()?;
     Ok(())


### PR DESCRIPTION
BREAKING CHANGE: this change the previous argument, where `language` is
the direct argument. Now it is the file input. I see this pattern is
more common than the previous design.
